### PR TITLE
Checking out now removes items from the cart

### DIFF
--- a/app.py
+++ b/app.py
@@ -141,6 +141,9 @@ def post_order():
 
     db.session.commit()
 
+    for item in session.get('items'):
+        session.pop(item, None)
+
     return '', 200
 
 


### PR DESCRIPTION
Now when a user completes checking out, the items from their cart are automatically removed from cart.

Fixes #12 